### PR TITLE
Fix deployment failure in pip-less environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
 - ANSIBLE_VERSION='ansible>=2.5.0,<2.6.0,!=2.5.1' # 2.5.x
 - ANSIBLE_VERSION='ansible>=2.4.0,<2.5.0' # 2.4.x
 - ANSIBLE_VERSION='ansible>=2.3.0,<2.4.0' # 2.3.x
-- LXC_DISTRO=debian LXC_RELEASE=jessie
-- LXC_DISTRO=ubuntu LXC_RELEASE=xenial
-- LXC_DISTRO=centos LXC_RELEASE=7
+- LXC_DISTRO=debian LXC_RELEASE=jessie ANSIBLE_VERSION='ansible!=2.5.1'
+- LXC_DISTRO=ubuntu LXC_RELEASE=xenial ANSIBLE_VERSION='ansible!=2.5.1'
+- LXC_DISTRO=centos LXC_RELEASE=7 ANSIBLE_VERSION='ansible!=2.5.1'
 matrix:
   fast_finish: true
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_cache:
 install:
 - sudo tar xf $HOME/lxc/cache.tar -C / || true
 - sudo apt-get install -y expect-dev
-- pip install ansible
+- if [ "$ANSIBLE_VERSION" ]; then pip install $ANSIBLE_VERSION; else pip install ansible; fi
 - ansible --version
 - printf '[defaults]\nroles_path=../\ncallback_whitelist=profile_tasks' >ansible.cfg
 - ansible-galaxy install lae.travis-lxc azavea.pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 env:
 # The following default to Debian Stretch
 - ANSIBLE_VERSION='git+https://github.com/ansible/ansible.git@devel' # 2.6 DEVEL
-- ANSIBLE_VERSION='ansible>=2.5.0,<2.6.0' # 2.5.x
+- ANSIBLE_VERSION='ansible>=2.5.0,<2.6.0,!=2.5.1' # 2.5.x
 - ANSIBLE_VERSION='ansible>=2.4.0,<2.5.0' # 2.4.x
 - ANSIBLE_VERSION='ansible>=2.3.0,<2.4.0' # 2.3.x
 - LXC_DISTRO=debian LXC_RELEASE=jessie

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,5 +8,5 @@ docker_restart_on_upgrade: yes
 docker_compose_install: no
 docker_compose_version: '1.20.*'
 
-docker_python_install: false
+docker_python_install: no
 docker_python_version: "3.1.*"

--- a/tasks/environment_check.yml
+++ b/tasks/environment_check.yml
@@ -5,4 +5,18 @@
       - "ansible_architecture == 'x86_64'"
     msg: "Docker CE is only supported on 64-bit systems. Install a 64-bit OS in order to use this role."
 
+- command: "python -c 'import pip'"
+  register: __docker_pip_import
+  ignore_errors: yes
+
+- set_fact:
+    __docker_pip_exists: '{{ True if (__docker_pip_import.rc == 0) else False }}'
+
+- name: Ensure pip is available if we are installing docker-py or compose
+  fail:
+    msg: "Was unable to import pip via Ansible - is pip installed?"
+  when:
+    - not __docker_pip_exists
+    - (docker_compose_install or docker_python_install)
+
 # vim:ft=ansible

--- a/tasks/environment_check.yml
+++ b/tasks/environment_check.yml
@@ -8,6 +8,7 @@
 - command: "python -c 'import pip'"
   register: __docker_pip_import
   ignore_errors: yes
+  changed_when: False
 
 - set_fact:
     __docker_pip_exists: '{{ True if (__docker_pip_import.rc == 0) else False }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,9 +49,11 @@
     name: docker
     version: "{{ docker_python_version }}"
     state: "{{ 'present' if (docker_compose_install or docker_python_install) else 'absent' }}"
+  when: __docker_pip_exists
 
 - name: Install docker-compose via PyPI
   pip:
     name: docker-compose
     version: "{{ docker_compose_version }}"
     state: "{{ 'present' if docker_compose_install else 'absent' }}"
+  when: __docker_pip_exists

--- a/tests/deploy.yml
+++ b/tests/deploy.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: docker,docker_compose
+- hosts: docker
   any_errors_fatal: true
   roles:
     - ansible-role-docker

--- a/tests/group_vars/docker
+++ b/tests/group_vars/docker
@@ -1,3 +1,2 @@
 ---
 ansible_ssh_user: root
-docker_python_install: yes

--- a/tests/group_vars/docker_compose
+++ b/tests/group_vars/docker_compose
@@ -1,3 +1,2 @@
 ---
-ansible_ssh_user: root
 docker_compose_install: yes

--- a/tests/group_vars/docker_python
+++ b/tests/group_vars/docker_python
@@ -1,0 +1,2 @@
+---
+docker_python_install: yes

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -4,11 +4,9 @@
   roles:
     - { name: lae.travis-lxc }
   vars:
-    host_quantity: 2
+    host_quantity: 3
 
 - hosts: all
-  roles:
-    - { name: azavea.pip }
   tasks:
     - name: Make cgroups modifiable
       mount:
@@ -40,3 +38,7 @@
         - cpuacct
         - net_cls
         - net_prio
+
+- hosts: docker_python:docker_compose
+  roles:
+    - { name: azavea.pip }

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,5 +1,8 @@
 [docker]
-test01.lxc
+test[01:03].lxc
+
+[docker_python]
+test02.lxc
 
 [docker_compose]
-test02.lxc
+test03.lxc

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: docker
+- hosts: docker_python
   tasks:
     - name: Pull an Alpine-based Nginx image
       docker_image:
@@ -27,11 +27,14 @@
     - name: Test that docker-compose is functional
       shell: "docker-compose version"
 
-- hosts: docker,docker_compose
+- hosts: docker_python:docker_compose
   tasks:
     - name: Test that the Nginx container is functional
       uri:
         url: "http://{{ inventory_hostname }}:8080"
+
+- hosts: docker
+  tasks:
     - block:
       - name: Docker daemon status (systemd)
         shell: systemctl status docker.service


### PR DESCRIPTION
This adds a test of deploying without the Docker python library and related environment checks.

This also disables testing on ansible 2.5.1...but will be re-enabled shortly.